### PR TITLE
Add .vscode/settings.json for contributor experience

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+  "[python]": {
+    "editor.codeActionsOnSave": {
+      "source.fixAll": "explicit"
+    },
+    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.formatOnSave": true
+  },
+  "esbonio.sphinx.confDir": "",
+  "python.testing.pytestArgs": ["."],
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestEnabled": true
+}


### PR DESCRIPTION
Closes #17

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds VS Code workspace settings only, affecting developer tooling but not runtime code or packaging.
> 
> **Overview**
> Adds a committed `.vscode/settings.json` to standardize contributor editor behavior for Python: format-on-save using Ruff, explicit fix-all actions on save, and VS Code test integration configured to run `pytest` (with `unittest` disabled). Also sets an `esbonio` Sphinx config directory value for documentation tooling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60df7f1412c2c5af628415f6e5ca6da0794e8b17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->