### PR TITLE
Add Ruff configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,7 @@ fallback_version = "0.0.0"
 
 [tool.pytest.ini_options]
 xfail_strict = true
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88


### PR DESCRIPTION
Add [tool.ruff] configuration to pyproject.toml (target-version, line-length).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds lint/format configuration and does not change runtime code or behavior.
> 
> **Overview**
> Adds a new `[tool.ruff]` section in `pyproject.toml`, setting `target-version = "py312"` and `line-length = 88` to standardize Ruff’s linting/formatting behavior across the project.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a74fc8ab58f896a37cffcdbf8c213542d03dfc07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->