### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{py,rst,toml,yaml,yml}]
+indent_style = space
+indent_size = 4
+
+[*.md]
+indent_size = 2


### PR DESCRIPTION
Add .editorconfig for consistent editor settings (indent, charset, line endings).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only introduces editor formatting rules and does not change runtime code or behavior.
> 
> **Overview**
> Introduces an `.editorconfig` that standardizes **charset/line endings**, enforces *final newlines* and *trailing-whitespace trimming*, and sets indentation rules (4 spaces for `py/rst/toml/yaml/yml`, 2 spaces for `md`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4dc2c9d9904144f132767cb57eeb4f94e923acb4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->