### PR TITLE
Add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: test lint format
+
+test:
+	uv run pytest
+
+lint:
+	uv run ruff check .
+	uv run ruff format --check .
+
+format:
+	uv run ruff format .
+	uv run ruff check --fix .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "httpx>=0.27.0",
     "respx>=0.22.0",
 ]
-optional-dependencies.dev = ["pytest>=7.0"]
+optional-dependencies.dev = ["pytest>=7.0", "ruff>=0.8"]
 
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
Add Makefile with test, lint, and format targets. Add ruff to dev dependencies.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: build tooling-only changes that don’t affect runtime behavior, aside from introducing `ruff` as a dev dependency for contributors.
> 
> **Overview**
> Adds a `Makefile` with `test`, `lint`, and `format` targets that run `pytest` and `ruff` via `uv` for consistent local workflows.
> 
> Updates `pyproject.toml` to include `ruff` in `optional-dependencies.dev` so linting/formatting can be installed with the dev extras.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 798c52d80d511503bf4ccae5455b18943de39688. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->