### PR TITLE
Add Installation section to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,22 @@ openapi-mock
 
 Serve an OpenAPI spec as a mock with `respx`_.
 
+Installation
+------------
+
+.. code-block:: console
+
+   uv pip install openapi-mock
+
+Or with pip:
+
+.. code-block:: console
+
+   pip install openapi-mock
+
+Usage
+-----
+
 .. code-block:: python
 
    from openapi_mock import add_openapi_to_respx


### PR DESCRIPTION
Add Installation section with uv and pip install instructions.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change adding install commands; no runtime or API behavior is affected.
> 
> **Overview**
> Adds an **Installation** section to `README.rst` with `uv pip install openapi-mock` and `pip install openapi-mock` examples, and promotes the existing usage snippet under a new **Usage** heading.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83fdbb9a34e5177332ccc6814bb123623699f74b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->