### PR TITLE
Add coverage report.fail_under to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "httpx>=0.27.0",
     "respx>=0.22.0",
 ]
-optional-dependencies.dev = ["pytest>=7.0"]
+optional-dependencies.dev = ["pytest>=7.0", "pytest-cov>=6.0"]
 
 [tool.setuptools.packages.find]
 where = ["src"]
@@ -28,3 +28,9 @@ xfail_strict = true
 [tool.ruff]
 target-version = "py312"
 line-length = 88
+
+[tool.coverage.run]
+source = ["src/openapi_mock"]
+
+[tool.coverage.report]
+fail_under = 100

--- a/tests/test_openapi_mock.py
+++ b/tests/test_openapi_mock.py
@@ -24,3 +24,27 @@ def test_simple_path() -> None:
         response = httpx.get("https://api.example.com/pets")
     assert response.status_code == 200
     assert response.json() == {}
+
+
+def test_skips_non_dict_path_item() -> None:
+    """Non-dict path items are skipped."""
+    spec = {"paths": {"/pets": "invalid"}}
+    with respx.mock(base_url="https://api.example.com", assert_all_called=False) as m:
+        add_openapi_to_respx(m, spec, base_url="https://api.example.com")
+    # No route added, nothing to assert
+
+
+def test_skips_non_http_methods() -> None:
+    """Non-HTTP methods are skipped."""
+    spec = {"paths": {"/pets": {"parameters": []}}}
+    with respx.mock(base_url="https://api.example.com", assert_all_called=False) as m:
+        add_openapi_to_respx(m, spec, base_url="https://api.example.com")
+    # No route added
+
+
+def test_skips_non_dict_operation() -> None:
+    """Non-dict operations are skipped."""
+    spec = {"paths": {"/pets": {"get": "invalid"}}}
+    with respx.mock(base_url="https://api.example.com", assert_all_called=False) as m:
+        add_openapi_to_respx(m, spec, base_url="https://api.example.com")
+    # No route added


### PR DESCRIPTION
Add pytest-cov, coverage config with fail_under=100, and tests for edge cases.

Closes #41

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only test suite and tooling configuration changes; no production logic is modified.
> 
> **Overview**
> Adds `pytest-cov` to dev dependencies and introduces `coverage` configuration in `pyproject.toml`, limiting measurement to `src/openapi_mock` and enforcing **100% minimum coverage** via `fail_under = 100`.
> 
> Expands tests to cover edge cases where `add_openapi_to_respx` should *skip* invalid OpenAPI `paths` entries (non-dict path items, non-HTTP method keys like `parameters`, and non-dict operations).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42b0e3f0a4eab938374c6b1de62b852904684036. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->