### PR TITLE
Add pyright --verifytypes for API completeness

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,10 @@ repos:
     hooks:
       - id: pyroma
         args: ["--min=10", "."]
+  - repo: local
+    hooks:
+      - id: pyright-verifytypes
+        name: pyright verifytypes
+        entry: uv run pyright --ignoreexternal --verifytypes openapi_mock
+        language: system
+        pass_filenames: false

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -22,3 +22,10 @@ Linting
 
    uv run ruff check .
    uv run ruff format --check .
+
+Type checking
+-------------
+
+.. code-block:: console
+
+   uv run pyright --ignoreexternal --verifytypes openapi_mock


### PR DESCRIPTION
Closes #22

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds a type-checking pre-commit hook and documents how to run it, without changing runtime code paths.
> 
> **Overview**
> Adds a local pre-commit hook to run `pyright --ignoreexternal --verifytypes openapi_mock`, enforcing stricter type completeness checks during development.
> 
> Updates `CONTRIBUTING.rst` to document the new type-checking command alongside the existing linting workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 533f1eaf3668e4529c404d429e7cb309cd3e0359. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->