### PR TITLE
Add pre-commit ci.skip for hooks requiring dev deps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ ci:
     - ruff
     - ruff-format
     - pyroma
+    - pyright-verifytypes
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
Closes #25

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts pre-commit CI configuration to skip selected hooks; no runtime or library behavior changes.
> 
> **Overview**
> Configures `pre-commit.ci` to **skip running** the `ruff`, `ruff-format`, `pyroma`, and `pyright-verifytypes` hooks in CI, leaving them for local/dev environments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b9c2fcfaa7ef0aeb5e6d2b75cdff8acd81667f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->