### PR TITLE
Add setuptools zip-safe = false

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ dependencies = [
 ]
 optional-dependencies.dev = ["pytest>=7.0", "pytest-cov>=6.0", "ruff>=0.8", "pyright>=1.1", "pyroma>=3.2"]
 
+[tool.setuptools]
+zip-safe = false
+
 [tool.setuptools.packages.find]
 where = ["src"]
 


### PR DESCRIPTION
Partial fix for #10

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk packaging-only change that affects how the library is installed/distributed but does not touch runtime code paths.
> 
> **Overview**
> Sets `zip-safe = false` under `[tool.setuptools]` in `pyproject.toml`, ensuring the built distribution is treated as not safe to run from a zipped egg/zip import and is installed unpacked.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5aa50983575c0c36127d72f431b7668309666716. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->