### PR TITLE
Pin uv version in pre-commit additional_dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,7 @@ repos:
     hooks:
       - id: pyright-verifytypes
         name: pyright verifytypes
-        entry: uv run pyright --ignoreexternal --verifytypes openapi_mock
-        language: system
+        entry: uv run --extra=dev -m pyright --ignoreexternal --verifytypes openapi_mock
+        language: python
         pass_filenames: false
+        additional_dependencies: [uv==0.9.5]


### PR DESCRIPTION
Fixes #31

Use language: python with uv==0.9.5 so pre-commit runs with a
consistent uv version, independent of the project's uv.lock.

Reference: requests-mock-flask .pre-commit-config.yaml

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only the `pre-commit` configuration to run `pyright` via a pinned `uv` version, with minimal impact beyond local tooling behavior.
> 
> **Overview**
> Makes the `pyright-verifytypes` pre-commit hook run with a consistent, pinned `uv` version by switching it to `language: python`, invoking `pyright` via `uv run --extra=dev -m pyright`, and adding `additional_dependencies: [uv==0.9.5]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23494cad3675e42008d967ed0a40b27a506b3eb1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->