### PR TITLE
Fix pre-commit ci.skip: only skip pyright-verifytypes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,5 @@
 ci:
   skip:
-    - ruff
-    - ruff-format
-    - pyroma
     - pyright-verifytypes
 
 repos:


### PR DESCRIPTION
Addresses https://github.com/adamtheturtle/openapi-mock/pull/74#pullrequestreview-3871897398

**Bugbot feedback:** The `ruff` and `ruff-format` hooks are sourced from the remote `astral-sh/ruff-pre-commit` repository, so pre-commit.ci installs them in their own isolated environment automatically — they do not require the project's dev dependencies. Adding them to `ci.skip` meant linting and formatting checks wouldn't run on pre-commit.ci, losing CI coverage.

**Fix:** Remove `ruff`, `ruff-format`, and `pyroma` from `ci.skip`. Only the local `pyright-verifytypes` hook (which uses `uv run --extra=dev`) genuinely requires dev deps to be pre-installed.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adjusts pre-commit.ci configuration only, re-enabling existing lint/format/package-quality checks; no runtime or application code changes.
> 
> **Overview**
> Updates `.pre-commit-config.yaml` so pre-commit.ci skips **only** the local `pyright-verifytypes` hook, and no longer skips `ruff`, `ruff-format`, or `pyroma`.
> 
> This restores CI coverage for linting/formatting and package-quality checks while keeping the dev-dependency-based type verification opt-out on pre-commit.ci.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56b10d160abc1f36b87ba29ff9014cd0aa6ca42f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->