### PR TITLE
Add README badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,14 @@
 openapi-mock
 ============
 
+|Build Status| |PyPI|
+
 Serve an OpenAPI spec as a mock with `respx`_.
+
+.. |Build Status| image:: https://github.com/adamtheturtle/openapi-mock/actions/workflows/ci.yml/badge.svg?branch=main
+   :target: https://github.com/adamtheturtle/openapi-mock/actions/workflows/ci.yml
+.. |PyPI| image:: https://badge.fury.io/py/openapi-mock.svg
+   :target: https://badge.fury.io/py/openapi-mock
 
 Installation
 ------------


### PR DESCRIPTION
Fixes #12

- Build Status (CI workflow)
- PyPI badge

Note: Build Status will work once the CI workflow PR is merged.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds external badge links; no runtime behavior or API surface is affected.
> 
> **Overview**
> Adds **Build Status** and **PyPI** badges to `README.rst`, including the reStructuredText image/link definitions pointing to the GitHub Actions CI workflow and the package’s PyPI badge.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2014771a8735692efa576d90b7ffe7d6a3c7456. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->