### PR TITLE
Use tmp_path as appropriate in tests

### DIFF
--- a/tests/test_load_spec.py
+++ b/tests/test_load_spec.py
@@ -1,6 +1,5 @@
 """Tests for load_spec."""
 
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -8,42 +7,42 @@ import pytest
 from openapi_mock import load_spec
 
 
-def test_load_json() -> None:
+def test_load_json(tmp_path: Path) -> None:
     """JSON files are loaded correctly."""
     spec = {"openapi": "3.0.0", "paths": {}}
-    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
-        Path(f.name).write_text('{"openapi": "3.0.0", "paths": {}}')
-        result = load_spec(f.name)
+    path = tmp_path / "spec.json"
+    path.write_text('{"openapi": "3.0.0", "paths": {}}')
+    result = load_spec(path)
     assert result == spec
 
 
-def test_load_yaml() -> None:
+def test_load_yaml(tmp_path: Path) -> None:
     """YAML files are loaded correctly."""
-    with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as f:
-        Path(f.name).write_text("openapi: 3.0.0\npaths: {}")
-        result = load_spec(f.name)
+    path = tmp_path / "spec.yaml"
+    path.write_text("openapi: 3.0.0\npaths: {}")
+    result = load_spec(path)
     assert result == {"openapi": "3.0.0", "paths": {}}
 
 
-def test_load_yml_extension() -> None:
+def test_load_yml_extension(tmp_path: Path) -> None:
     """Files with .yml extension are loaded as YAML."""
-    with tempfile.NamedTemporaryFile(suffix=".yml", delete=False) as f:
-        Path(f.name).write_text("openapi: 3.0.0\npaths: {}")
-        result = load_spec(f.name)
+    path = tmp_path / "spec.yml"
+    path.write_text("openapi: 3.0.0\npaths: {}")
+    result = load_spec(path)
     assert result == {"openapi": "3.0.0", "paths": {}}
 
 
-def test_load_path_object() -> None:
+def test_load_path_object(tmp_path: Path) -> None:
     """Path objects are accepted."""
-    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
-        Path(f.name).write_text("{}")
-        result = load_spec(Path(f.name))
+    path = tmp_path / "spec.json"
+    path.write_text("{}")
+    result = load_spec(path)
     assert result == {}
 
 
-def test_unsupported_format_raises() -> None:
+def test_unsupported_format_raises(tmp_path: Path) -> None:
     """Unsupported file formats raise ValueError."""
-    with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
-        Path(f.name).write_text("{}")
-        with pytest.raises(ValueError, match="Unsupported format"):
-            load_spec(f.name)
+    path = tmp_path / "spec.txt"
+    path.write_text("{}")
+    with pytest.raises(ValueError, match="Unsupported format"):
+        load_spec(path)


### PR DESCRIPTION
Closes #84

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a small, self-contained helper and dependency (`pyyaml`) plus unit tests, without changing the existing mocking behavior.
> 
> **Overview**
> Adds a new public helper `load_spec()` to load OpenAPI specs directly from disk, supporting both `.json` and `.yaml`/`.yml` inputs and raising `ValueError` for unsupported formats.
> 
> Introduces `pyyaml` as a runtime dependency (and updates `uv.lock`) and adds focused tests using `tmp_path` to validate JSON/YAML loading and error handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c2fbee46e1994e7e523c2cc563e8a8f74efab18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->