### PR TITLE
Use beartype everywhere

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,11 @@ classifiers = [
 ]
 urls = { Homepage = "https://github.com/adamtheturtle/openapi-mock" }
 dependencies = [
+    "beartype>=0.18",
     "httpx>=0.27.0",
     "respx>=0.22.0",
 ]
-optional-dependencies.dev = ["pytest>=7.0", "pytest-cov>=6.0", "ruff>=0.8", "pyright>=1.1", "pyroma>=3.2", "sybil[pytest]>=4.0", "beartype>=0.18"]
+optional-dependencies.dev = ["pytest>=7.0", "pytest-cov>=6.0", "ruff>=0.8", "pyright>=1.1", "pyroma>=3.2", "sybil[pytest]>=4.0"]
 
 [tool.setuptools]
 zip-safe = false

--- a/src/openapi_mock/__init__.py
+++ b/src/openapi_mock/__init__.py
@@ -4,8 +4,10 @@ from typing import Any, cast
 
 import httpx
 import respx
+from beartype import beartype
 
 
+@beartype
 def add_openapi_to_respx(
     mock_obj: respx.MockRouter | respx.Router,
     spec: dict[str, Any],


### PR DESCRIPTION
Closes #82

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces runtime type enforcement on a public API and adds a new required dependency, which can surface new exceptions in downstream usage and slightly impact performance.
> 
> **Overview**
> Adds `beartype` as a required install dependency (and removes it from `dev` extras).
> 
> Annotates the public `add_openapi_to_respx` entrypoint with `@beartype`, enabling runtime validation of its typed arguments and return value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a0500afd45359e27bfe17eb8ba8f13c8d4851a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->