### PR TITLE
Use * everywhere - require keyword arguments

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Usage
        "paths": {"/pets": {"get": {"responses": {"200": {"description": "OK"}}}}},
    }
    with respx.mock(base_url="https://api.example.com", assert_all_called=False) as m:
-       add_openapi_to_respx(m, spec, base_url="https://api.example.com")
+       add_openapi_to_respx(mock_obj=m, spec=spec, base_url="https://api.example.com")
        response = httpx.get("https://api.example.com/pets")
    assert response.status_code == 200
 

--- a/src/openapi_mock/__init__.py
+++ b/src/openapi_mock/__init__.py
@@ -7,6 +7,7 @@ import respx
 
 
 def add_openapi_to_respx(
+    *,
     mock_obj: respx.MockRouter | respx.Router,
     spec: dict[str, Any],
     base_url: str,

--- a/tests/test_openapi_mock.py
+++ b/tests/test_openapi_mock.py
@@ -20,7 +20,7 @@ def test_simple_path() -> None:
         base_url="https://api.example.com",
         assert_all_called=False,
     ) as m:
-        add_openapi_to_respx(m, spec, base_url="https://api.example.com")
+        add_openapi_to_respx(mock_obj=m, spec=spec, base_url="https://api.example.com")
         response = httpx.get("https://api.example.com/pets")
     assert response.status_code == 200
     assert response.json() == {}
@@ -30,7 +30,7 @@ def test_skips_non_dict_path_item() -> None:
     """Non-dict path items are skipped."""
     spec = {"paths": {"/pets": "invalid"}}
     with respx.mock(base_url="https://api.example.com", assert_all_called=False) as m:
-        add_openapi_to_respx(m, spec, base_url="https://api.example.com")
+        add_openapi_to_respx(mock_obj=m, spec=spec, base_url="https://api.example.com")
     # No route added, nothing to assert
 
 
@@ -38,7 +38,7 @@ def test_skips_non_http_methods() -> None:
     """Non-HTTP methods are skipped."""
     spec = {"paths": {"/pets": {"parameters": []}}}
     with respx.mock(base_url="https://api.example.com", assert_all_called=False) as m:
-        add_openapi_to_respx(m, spec, base_url="https://api.example.com")
+        add_openapi_to_respx(mock_obj=m, spec=spec, base_url="https://api.example.com")
     # No route added
 
 
@@ -46,5 +46,5 @@ def test_skips_non_dict_operation() -> None:
     """Non-dict operations are skipped."""
     spec = {"paths": {"/pets": {"get": "invalid"}}}
     with respx.mock(base_url="https://api.example.com", assert_all_called=False) as m:
-        add_openapi_to_respx(m, spec, base_url="https://api.example.com")
+        add_openapi_to_respx(mock_obj=m, spec=spec, base_url="https://api.example.com")
     # No route added


### PR DESCRIPTION
Closes #83

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a small API signature tightening to enforce keyword arguments; the only impact is a breaking change for callers still using positional args.
> 
> **Overview**
> `add_openapi_to_respx` now enforces *keyword-only* parameters by adding `*` to its signature, preventing positional-argument calls.
> 
> Docs and tests are updated to call it with explicit keywords (e.g., `mock_obj=...`, `spec=...`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb6e408eeb4f3b1a10845bb1d3a3eee5701b383c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->