### PR TITLE
Add pre-commit-ci/lite-action with if: always()

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Run pre-commit
         run: uv run --extra=dev pre-commit run --all-files
 
+      - uses: pre-commit-ci/lite-action@v1.1.0
+        if: always()
+
   completion-lint:
     needs: lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #43

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adds an extra GitHub Action step after `pre-commit`; it may slightly change lint job reporting/artifacts but does not affect runtime code.
> 
> **Overview**
> The lint GitHub Actions workflow now runs `pre-commit-ci/lite-action@v1.1.0` after the existing `pre-commit` invocation, guarded by `if: always()` so it executes even when earlier steps fail.
> 
> The existing `completion-lint` gate remains, so the workflow still fails the run when the `lint` job does not succeed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b9e05298733d3e0b1d6a5f71542d5fa7261b640. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->