### PR TITLE
Add release workflow for PyPI publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+---
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  id-token: write
+
+jobs:
+  pypi-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: "**/pyproject.toml"
+
+      - name: Build package
+        run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Closes #11

Uses trusted publishing (OIDC). Configure trusted publisher at https://pypi.org/manage/project/openapi-mock/settings/publishing/

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an automated PyPI publish path triggered on `release.published`, which can unintentionally ship broken artifacts if the build configuration or release process is misconfigured. Uses OIDC trusted publishing (no long-lived secrets), reducing credential risk.
> 
> **Overview**
> Adds a new GitHub Actions `Release` workflow that runs on `release: published`, builds the Python package with `uv build`, and publishes to PyPI via `pypa/gh-action-pypi-publish` using OIDC (`id-token: write`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2ad5c0171cd5267ab3922f57030243b4398ab5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->