### PR TITLE
Add Sphinx version validation in conf.py

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,7 +20,7 @@ author = _pyproject_config.author
 # Validate version - reject 0.x (indicates missing git tags)
 _version_string = importlib.metadata.version(distribution_name=project)
 _version = Version(version=_version_string)
-if _version.major == 0:
+if _version.release[0] == 0:
     msg = (
         f"The version is {_version_string}. "
         "This indicates that the version is not set correctly. "


### PR DESCRIPTION
Closes #35

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes that may fail the Sphinx build if packaging metadata reports a `0.x` version (e.g., missing git tags).
> 
> **Overview**
> Adds Sphinx build-time validation that rejects `0.x` package versions (treating them as misconfigured builds, likely missing Git tags) by raising a `ValueError` in `docs/source/conf.py`.
> 
> Derives a CalVer-style `release` string from the parsed package version and injects it into `rst_prolog` as the `|release|` substitution for use in the docs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c85b456feb16d47cd839e933fe12784b7109c7f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->