### PR TITLE
Add Sphinx intersphinx and nitpicky for doc quality

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -59,7 +59,9 @@ intersphinx_mapping = {
 }
 
 nitpicky = True
-# respx/httpx don't publish intersphinx inventories; ignore refs to their types
+# respx/httpx don't publish intersphinx inventories; ignore refs to their types.
+# See https://github.com/encode/httpx/discussions/3091 and
+# https://github.com/lundberg/respx/issues/305
 nitpick_ignore = [
     ("py:class", "respx.router.MockRouter"),
     ("py:class", "respx.router.Router"),


### PR DESCRIPTION
Closes #34

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only configuration changes, with the main impact being stricter build-time reference checking that could surface new doc build failures.
> 
> **Overview**
> Improves Sphinx doc quality checks by enabling `sphinx.ext.intersphinx` and turning on *nitpicky* mode to fail on unresolved references.
> 
> Adds an intersphinx mapping to Python docs keyed off the project’s minimum supported Python version, and explicitly ignores unresolved references to `respx` router classes that don’t publish inventories.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e7421cab487705bcd496aa616bcb457ce89ee85. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->