### PR TITLE
Add persist-credentials: false to publish-site checkout

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:


### PR DESCRIPTION
Closes #38

Adds `persist-credentials: false` to the checkout step in the publish-site workflow for consistency with CI and Lint workflows. Avoids credential leakage between jobs.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that reduces the chance of `GITHUB_TOKEN` credentials being reused or leaked across steps/jobs; no application code or runtime behavior changes.
> 
> **Overview**
> Updates the `publish-site` GitHub Actions workflow to set `persist-credentials: false` on the `actions/checkout@v4` step, aligning it with other workflows and preventing checkout from leaving credentials in the repo config for subsequent steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09c2813491cba38567c72de03992a83cb4317a18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->