### PR TITLE
Add release workflow for PyPI publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   pypi-publish:
     runs-on: ubuntu-latest
+    environment: release
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Closes #11

Adds Release workflow that runs on `release: published`, builds with `uv build`, and publishes to PyPI via `pypa/gh-action-pypi-publish` using OIDC trusted publishing.

Configure trusted publisher at https://pypi.org/manage/project/openapi-mock/settings/publishing/

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new release-triggered workflow that builds and publishes artifacts to PyPI using OIDC trusted publishing; misconfiguration could cause failed or unintended publishes. No runtime/product code paths change.
> 
> **Overview**
> Adds a new GitHub Actions `Release` workflow that runs on `release: published`, builds the Python package with `uv build`, and publishes it to PyPI via `pypa/gh-action-pypi-publish` using `id-token: write` (OIDC trusted publishing).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1f627f6096344f1eebbdecd2fb5e393445e3785. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->