### PR TITLE
Add pyproject-fmt (partial #6)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ ci:
     - pyright-docs
     - check-manifest
     - deptry
+    - pyproject-fmt
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -37,6 +38,14 @@ repos:
         args: ["--min=10", "."]
   - repo: local
     hooks:
+      - id: pyproject-fmt
+        name: pyproject-fmt
+        entry: uv run --extra=dev pyproject-fmt
+        language: python
+        types_or: [toml]
+        files: pyproject.toml
+        additional_dependencies: [uv==0.9.5]
+
       - id: check-manifest
         name: check-manifest
         entry: uv run --extra=dev -m check_manifest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,24 +1,24 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools", "setuptools-scm>=8.1.0"]
+requires = [ "setuptools", "setuptools-scm>=8.1.0" ]
 
 [project]
 name = "openapi-mock"
 description = "Serve an OpenAPI spec as a mock with respx."
 readme = { file = "README.rst", content-type = "text/x-rst" }
+keywords = [ "httpx", "mock", "openapi", "respx" ]
 license = "MIT"
-license-files = ["LICENSE"]
+license-files = [ "LICENSE" ]
+authors = [ { name = "Adam Dangoor", email = "adamdangoor@gmail.com" } ]
 requires-python = ">=3.12"
-dynamic = ["version"]
-authors = [{ name = "Adam Dangoor", email = "adamdangoor@gmail.com" }]
-keywords = ["openapi", "mock", "respx", "httpx"]
 classifiers = [
     "Development Status :: 4 - Beta",
-    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
-urls = { Homepage = "https://github.com/adamtheturtle/openapi-mock", Documentation = "https://adamtheturtle.github.io/openapi-mock/" }
+dynamic = [ "version" ]
 dependencies = [
     "beartype>=0.18",
     "httpx>=0.27.0",
@@ -30,68 +30,39 @@ dependencies = [
 optional-dependencies.dev = [
     "check-manifest==0.51",
     "deptry==0.24.0",
+    "doccmd==2026.1.27.2",
     "furo==2025.12.19",
+    "pre-commit==4.5.1",
+    "pyproject-fmt==2.16.1",
+    "pyright==1.1.408",
+    "pyroma==5.0.1",
     "pytest==9.0.2",
     "pytest-cov==7.0.0",
     "ruff==0.15.4",
-    "pyright==1.1.408",
-    "pyroma==5.0.1",
-    "sybil[pytest]==9.3.0",
-    "pre-commit==4.5.1",
     "sphinx==9.1.0",
     "sphinx-copybutton==0.5.2",
     "sphinx-lint==1.0.2",
     "sphinx-pyproject==0.3.0",
     "sphinx-substitution-extensions==2026.1.12",
     "sphinxcontrib-spelling==8.0.2",
-    "doccmd==2026.1.27.2",
+    "sybil[pytest]==9.3.0",
 ]
+urls = { Homepage = "https://github.com/adamtheturtle/openapi-mock", Documentation = "https://adamtheturtle.github.io/openapi-mock/" }
+scripts.openapi-mock = "openapi_mock.cli:main"
 
 [tool.setuptools]
 zip-safe = false
-
-[tool.setuptools.packages.find]
-where = ["src"]
-
-[project.scripts]
-openapi-mock = "openapi_mock.cli:main"
+packages.find.where = [ "src" ]
 
 [tool.setuptools_scm]
 fallback_version = "0.0.0"
 
-[tool.pytest.ini_options]
-xfail_strict = true
-log_cli = true
-
 [tool.ruff]
 target-version = "py312"
 line-length = 88
-lint.extend-select = ["C901", "ERA001"]
-lint.unfixable = ["ERA001"]
+lint.extend-select = [ "C901", "ERA001" ]
+lint.unfixable = [ "ERA001" ]
 lint.mccabe.max-complexity = 12
-
-[tool.pyproject-fmt]
-indent = 4
-keep_full_version = true
-max_supported_python = "3.14"
-
-[tool.coverage.run]
-source = ["src/openapi_mock"]
-branch = true
-
-[tool.coverage.report]
-fail_under = 100
-exclude_also = ["if TYPE_CHECKING:"]
-show_missing = true
-
-[tool.mypy]
-exclude = ["build", ".venv"]
-
-[tool.pyright]
-exclude = ["build", ".venv"]
-enableTypeIgnoreComments = false
-reportUnnecessaryTypeIgnoreComment = true
-typeCheckingMode = "strict"
 
 [tool.check-manifest]
 ignore = [
@@ -118,4 +89,29 @@ ignore = [
 ]
 
 [tool.deptry]
-pep621_dev_dependency_groups = ["dev"]
+pep621_dev_dependency_groups = [ "dev" ]
+
+[tool.pyproject-fmt]
+indent = 4
+keep_full_version = true
+max_supported_python = "3.14"
+
+[tool.pytest]
+ini_options.xfail_strict = true
+ini_options.log_cli = true
+
+[tool.coverage]
+run.branch = true
+run.source = [ "src/openapi_mock" ]
+report.exclude_also = [ "if TYPE_CHECKING:" ]
+report.fail_under = 100
+report.show_missing = true
+
+[tool.mypy]
+exclude = [ "build", ".venv" ]
+
+[tool.pyright]
+exclude = [ "build", ".venv" ]
+enableTypeIgnoreComments = false
+reportUnnecessaryTypeIgnoreComment = true
+typeCheckingMode = "strict"

--- a/uv.lock
+++ b/uv.lock
@@ -643,6 +643,7 @@ dev = [
     { name = "doccmd" },
     { name = "furo" },
     { name = "pre-commit" },
+    { name = "pyproject-fmt" },
     { name = "pyright" },
     { name = "pyroma" },
     { name = "pytest" },
@@ -666,6 +667,7 @@ requires-dist = [
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = "==4.5.1" },
+    { name = "pyproject-fmt", marker = "extra == 'dev'", specifier = "==2.16.1" },
     { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.408" },
     { name = "pyroma", marker = "extra == 'dev'", specifier = "==5.0.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.0.2" },
@@ -755,6 +757,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyproject-fmt"
+version = "2.16.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "toml-fmt-common" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3c/c1/fb6d0e21c7efc28f86976ab43c5b5b9c0575533aa1b22560fcf51a92854f/pyproject_fmt-2.16.1.tar.gz", hash = "sha256:365da327232a97c7e10baa72d39c896777147217a72c6b01ae2b30543bfc7f44", size = 138536, upload-time = "2026-02-18T02:15:16.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/42/ba3900c436c318d02a69a535d4d393bdecb5c22310fffca634e10a7a3fe2/pyproject_fmt-2.16.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:29a3a5ecdc2f5e860da2a692c0f12b1262b59ab78e90e43e4aae3f43e6173cbd", size = 4751598, upload-time = "2026-02-18T02:14:54.306Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/b26e05681a0f18aff2a9a78c17568e4465b7938c70d8d66162ffb43e1ac6/pyproject_fmt-2.16.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:3d00c40be58d94293ee315bf4ed5837c85422e1f4f8a19d22f9aaa45ff63d73d", size = 4565298, upload-time = "2026-02-18T02:14:56.921Z" },
+    { url = "https://files.pythonhosted.org/packages/50/f5/7145d65688db0dca0c8c793df2e6599990168d5e2e91cefa6dde65795f35/pyproject_fmt-2.16.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d4287e2dff17eebeab18ec4e02e92bda9ee863731db31ef52dcc0b5847742c52", size = 4712814, upload-time = "2026-02-18T02:14:58.74Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/be/9344881d701c6d4f591640992f579cb290e1e5464b3885cbf2b825668d49/pyproject_fmt-2.16.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:5c34436a9ed933c967cd2ee8e68d7df52a9e9dcb1fab49de0520724c8a18bd2c", size = 5016591, upload-time = "2026-02-18T02:15:00.743Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/f1/0b8eb87cbd26a5d26ac32b3f9ce88a1dd24ba95e817332c3388e947dd34f/pyproject_fmt-2.16.1-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:748ff422e2501398be9df2ab6672a12d7254d7502c0fb7466d67828213de8591", size = 4749301, upload-time = "2026-02-18T02:15:03.935Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/3a/39f97bef77ac5ca9e3d52be1cf1a606839ccc48c1dfc1b910d8a3bd54a9a/pyproject_fmt-2.16.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b6cab1240ce8fabdb885d79a85e5960b5c93e74973422fe76687513c5d594ca9", size = 5214843, upload-time = "2026-02-18T02:15:06.626Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c4/60e86f0471be6418d966bc8fb1dbc8af4ee03eadc3e56eeb90e384ed2d82/pyproject_fmt-2.16.1-cp39-abi3-win_amd64.whl", hash = "sha256:49286a6b2b1e92d6bc92c7b7f2885e8776d9f7956f5ec08aebd0b56edf67e2e9", size = 4862276, upload-time = "2026-02-18T02:15:08.362Z" },
 ]
 
 [[package]]
@@ -1274,6 +1294,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b0/7b/972027f1594400d9671c3b26eb38ef41fefe114efda1579f99240a063072/sybil_extras-2026.1.22.tar.gz", hash = "sha256:d063567d694946ad1e093dd96a6c512bf80d04f46e9a747080dcb043c2128c5d", size = 74720, upload-time = "2026-01-22T12:46:24.191Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9f/df/c62aad2dabb3d47c7ce020f8bc93eb664346127722bc4138f261febea828/sybil_extras-2026.1.22-py2.py3-none-any.whl", hash = "sha256:6d2688495bd071230460d0a91e1ce1e84a2f800501c9e6fbde3d7f2825a3bca1", size = 57624, upload-time = "2026-01-22T12:46:22.76Z" },
+]
+
+[[package]]
+name = "toml-fmt-common"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/26/00c52fb55720e0e3056d59936f959e9dcb7a5caf3a21619eb5c2ba7b5144/toml_fmt_common-1.2.0.tar.gz", hash = "sha256:9c3630dc9409157e866b27ee0cdacf453636735b26dcf0fff385d3d2c1166698", size = 9735, upload-time = "2026-01-30T08:37:45.131Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/bb/aabb52533ec79abccbed8b8fcef386e4037f581c42fc0331e859039619da/toml_fmt_common-1.2.0-py3-none-any.whl", hash = "sha256:f27ba0f4a3594035f3385231d23d437a49bd6ff67ec624424a677c2b304076d3", size = 5699, upload-time = "2026-01-30T08:37:44.069Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds pyproject-fmt to dev dependencies and pre-commit hook.
Applies pyproject-fmt formatting to pyproject.toml.
Skips in pre-commit CI.

Helps #6

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds a formatting tool and rewrites `pyproject.toml` structure/formatting; functional runtime code is unchanged and risk is limited to potential tooling/config parsing differences.
> 
> **Overview**
> Adds `pyproject-fmt` to the dev toolchain: a new local pre-commit hook (run via `uv`) is introduced and skipped in pre-commit CI, and `pyproject-fmt` is added to dev dependencies (with corresponding `uv.lock` updates).
> 
> Reformats and restructures `pyproject.toml` to match `pyproject-fmt` conventions, including minor metadata tweaks (e.g., classifiers/keywords) and converting several tool sections (e.g., `pytest`, `coverage`, `setuptools`) to equivalent dotted-key TOML layout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba5adefb626ea552c624e04378a56caf8d856ddd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->