### PR TITLE
Add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -1,0 +1,24 @@
+---
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #105

Adds workflow to enable auto-merge for Dependabot PRs when CI passes.
Uses dependabot/fetch-metadata and `gh pr merge --auto --merge`.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new GitHub Actions workflow that can automatically merge Dependabot PRs, which increases the chance of unintended dependency updates landing if CI or metadata checks are insufficient. Scope is limited to CI automation and uses the repo-scoped `GITHUB_TOKEN`.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`dependabot-merge.yml`) that runs on `pull_request` events and, when the actor is `dependabot[bot]`, enables GitHub auto-merge via `gh pr merge --auto --merge`.
> 
> The job requests `contents: write` and `pull-requests: write` permissions and fetches Dependabot metadata using `dependabot/fetch-metadata@v2` before triggering auto-merge.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6769f655e8f51277fe8a8ca50ff26368b9150997. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->