### PR TITLE
Use permissions: {} for CI and Lint workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,7 @@ on:
   schedule:
     - cron: 0 1 * * *
 
-permissions:
-  contents: read  # required for checkout
+permissions: {}
 
 jobs:
   build:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,8 +8,7 @@ on:
     branches: [main]
   workflow_dispatch: {}
 
-permissions:
-  contents: read  # required for checkout
+permissions: {}
 
 jobs:
   lint:


### PR DESCRIPTION
Closes #37

Use `permissions: {}` (empty) for CI and Lint workflows - least privilege, no default GITHUB_TOKEN permissions.

Only release, dependabot-merge, and publish-site need elevated permissions.

Reference: requests-mock-flask/.github/workflows/

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk YAML-only change that tightens GitHub Actions token permissions; main risk is unexpected permission needs for future steps that rely on `GITHUB_TOKEN` write access.
> 
> **Overview**
> Tightens GitHub Actions security by changing the `CI` and `Lint` workflows to use `permissions: {}` (no default `GITHUB_TOKEN` permissions) instead of granting `contents: read`.
> 
> This enforces least-privilege for these workflows and relies on `checkout` running with `persist-credentials: false` rather than workflow-level token scopes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8514d09aaa86ce918ec4fab7d2a69e7a8da5a0a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->