### PR TITLE
Add py.typed package-data (#116)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ scripts.openapi-mock = "openapi_mock.cli:main"
 
 [tool.setuptools]
 zip-safe = false
+package-data.openapi_mock = [ "py.typed" ]
 packages.find.where = [ "src" ]
 
 [tool.setuptools_scm]


### PR DESCRIPTION
Closes #116

Add `package-data.openapi_mock = ["py.typed"]` so the py.typed marker is included in the built wheel. The py.typed file already exists in the repo.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk packaging-only change that affects what files are included in built wheels, with no runtime logic modifications.
> 
> **Overview**
> Ensures the `py.typed` marker file is included in built distributions by adding `package-data.openapi_mock = ["py.typed"]` to `pyproject.toml`, improving downstream type-checker support for the `openapi_mock` package.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec6eb7e4293d6c5b44e93aba9315b0c2639aefb7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->