### PR TITLE
Pre-commit: meta hook, v6, extra hooks, fail_fast (#120)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,6 @@
 ---
+fail_fast: true
+
 ci:
   skip:
     - pyright-verifytypes
@@ -7,36 +9,65 @@ ci:
     - deptry
     - pyproject-fmt
 
+default_install_hook_types: [pre-commit, pre-push]
+
 repos:
+  - repo: meta
+    hooks:
+      - id: check-useless-excludes
+        stages: [pre-commit]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
+        stages: [pre-commit]
       - id: check-case-conflict
+        stages: [pre-commit]
+      - id: check-executables-have-shebangs
+        stages: [pre-commit]
       - id: check-merge-conflict
+        stages: [pre-commit]
+      - id: check-shebang-scripts-are-executable
+        stages: [pre-commit]
+      - id: check-symlinks
+        stages: [pre-commit]
       - id: check-json
+        stages: [pre-commit]
       - id: check-toml
+        stages: [pre-commit]
+      - id: check-vcs-permalinks
+        stages: [pre-commit]
       - id: check-yaml
+        stages: [pre-commit]
       - id: end-of-file-fixer
+        stages: [pre-commit]
       - id: trailing-whitespace
+        stages: [pre-commit]
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:
       - id: rst-directive-colons
+        stages: [pre-commit]
       - id: rst-inline-touching-normal
+        stages: [pre-commit]
       - id: text-unicode-replacement-char
+        stages: [pre-commit]
       - id: rst-backticks
+        stages: [pre-commit]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.4
     hooks:
       - id: ruff
         args: [--fix]
+        stages: [pre-commit]
       - id: ruff-format
+        stages: [pre-commit]
   - repo: https://github.com/regebro/pyroma
     rev: 5.0.1
     hooks:
       - id: pyroma
         args: [--min=10, .]
+        stages: [pre-commit]
   - repo: local
     hooks:
       - id: doc8
@@ -45,6 +76,7 @@ repos:
         language: python
         pass_filenames: false
         additional_dependencies: [uv==0.9.5]
+        stages: [pre-commit]
 
       - id: interrogate
         name: interrogate
@@ -52,6 +84,7 @@ repos:
         language: python
         pass_filenames: false
         additional_dependencies: [uv==0.9.5]
+        stages: [pre-commit]
 
       - id: pydocstringformatter
         name: pydocstringformatter
@@ -60,6 +93,7 @@ repos:
         pass_filenames: false
         types: [python]
         additional_dependencies: [uv==0.9.5]
+        stages: [pre-commit]
 
       - id: vulture
         name: vulture
@@ -67,6 +101,7 @@ repos:
         language: python
         pass_filenames: false
         additional_dependencies: [uv==0.9.5]
+        stages: [pre-commit]
 
       - id: yamlfix
         name: yamlfix
@@ -74,6 +109,7 @@ repos:
         language: python
         types: [yaml]
         additional_dependencies: [uv==0.9.5]
+        stages: [pre-commit]
 
       - id: pyproject-fmt
         name: pyproject-fmt
@@ -82,6 +118,7 @@ repos:
         types_or: [toml]
         files: pyproject.toml
         additional_dependencies: [uv==0.9.5]
+        stages: [pre-commit]
 
       - id: check-manifest
         name: check-manifest
@@ -89,6 +126,7 @@ repos:
         language: python
         pass_filenames: false
         additional_dependencies: [uv==0.9.5]
+        stages: [pre-commit]
 
       - id: deptry
         name: deptry
@@ -96,6 +134,7 @@ repos:
         language: python
         pass_filenames: false
         additional_dependencies: [uv==0.9.5]
+        stages: [pre-commit]
 
       - id: pyright-verifytypes
         name: pyright verifytypes
@@ -103,6 +142,7 @@ repos:
         language: python
         pass_filenames: false
         additional_dependencies: [uv==0.9.5]
+        stages: [pre-push]
 
       - id: pyright-docs
         name: pyright-docs
@@ -111,6 +151,7 @@ repos:
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
+        stages: [pre-push]
 
       - id: linkcheck
         name: linkcheck

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Configuration for Sphinx."""
 
 import importlib.metadata


### PR DESCRIPTION
Closes #120

- Add fail_fast: true and default_install_hook_types: [pre-commit, pre-push]
- Add meta repo with check-useless-excludes
- Upgrade pre-commit-hooks v5.0.0 → v6.0.0
- Add check-executables-have-shebangs, check-shebang-scripts-are-executable, check-symlinks, check-vcs-permalinks
- Add explicit stages to all hooks
- Remove shebang from docs/source/conf.py (not meant to be executable)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since changes are limited to developer tooling and Sphinx config executability; main impact is stricter local/CI checks that could block commits/pushes if new hooks fail.
> 
> **Overview**
> Tightens the pre-commit setup by enabling `fail_fast`, setting `default_install_hook_types` for `pre-commit`/`pre-push`, upgrading `pre-commit-hooks` to `v6.0.0`, and adding extra repository hooks (including `meta`'s `check-useless-excludes` plus new shebang/symlink/permalink checks).
> 
> Makes hook execution more explicit by assigning `stages` across hooks (moving heavier checks like `pyright-*` to `pre-push`) and removes the shebang from `docs/source/conf.py` so it’s not treated as an executable script.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0dbb68df98d38d69337b767c1173f3f1124661c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->