### PR TITLE
Add release workflow like requests-mock-flask

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,36 +1,106 @@
 ---
 name: Release
 
-on:
-  release:
-    types: [published]
-
-permissions:
-  contents: read  # required for checkout
-  id-token: write
+on: workflow_dispatch
 
 jobs:
-  pypi-publish:
+  build:
+    name: Publish a release
     runs-on: ubuntu-latest
+
+    # Specifying an environment is strongly recommended by PyPI.
+    # See https://github.com/pypa/gh-action-pypi-publish/tree/release/v1/?tab=readme-ov-file#trusted-publishing.
     environment: release
 
+    permissions:
+      # This is needed for PyPI publishing.
+      # See https://github.com/pypa/gh-action-pypi-publish/tree/release/v1/?tab=readme-ov-file#trusted-publishing.
+      id-token: write
+      # This is needed for https://github.com/stefanzweifel/git-auto-commit-action.
+      contents: write
+
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
+          # See
+          # https://github.com/stefanzweifel/git-auto-commit-action?tab=readme-ov-file#push-to-protected-branches
+          token: ${{ secrets.RELEASE_PAT }}
+          # Fetch all history including tags.
+          # Needed to find the latest tag.
+          #
+          # Also, avoids
+          # https://github.com/stefanzweifel/git-auto-commit-action/issues/99.
           fetch-depth: 0
-          fetch-tags: true
-          persist-credentials: false
+
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
 
-      - name: Build package
-        run: uv build --out-dir dist/
+      - name: Calver calculate version
+        uses: StephaneBour/actions-calver@master
+        id: calver
+        with:
+          date_format: '%Y.%m.%d'
+          release: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Check wheel contents
-        run: uv run --extra=release check-wheel-contents dist/*.whl
+      - name: Get the changelog underline
+        id: changelog_underline
+        run: |
+          underline="$(echo "${{ steps.calver.outputs.release }}" | tr -c '\n' '-')"
+          echo "underline=${underline}" >> "$GITHUB_OUTPUT"
 
-      - name: Publish to PyPI
+      - name: Update changelog
+        uses: jacobtomlinson/gha-find-replace@v3
+        with:
+          find: "Next\n----"
+          replace: |
+            Next
+            ----
+
+            ${{ steps.calver.outputs.release }}
+            ${{ steps.changelog_underline.outputs.underline }}
+          include: CHANGELOG.rst
+          regex: false
+
+      - uses: stefanzweifel/git-auto-commit-action@v7
+        id: commit
+        with:
+          commit_message: Bump CHANGELOG
+          file_pattern: CHANGELOG.rst
+          # Error if there are no changes.
+          skip_dirty_check: true
+
+      - name: Bump version and push tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          custom_tag: ${{ steps.calver.outputs.release }}
+          tag_prefix: ''
+          commit_sha: ${{ steps.commit.outputs.commit_hash }}
+
+      - name: Create a GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.tag_version.outputs.new_tag }}
+          makeLatest: true
+          name: Release ${{ steps.tag_version.outputs.new_tag }}
+          body: ${{ steps.tag_version.outputs.changelog }}
+
+      - name: Build a binary wheel and a source tarball
+        run: |
+          git fetch --tags
+          git checkout ${{ steps.tag_version.outputs.new_tag }}
+          uv build --sdist --wheel --out-dir dist/
+          uv run --extra=release check-wheel-contents dist/*.whl
+
+      # We use PyPI trusted publishing rather than a PyPI API token.
+      # See https://github.com/pypa/gh-action-pypi-publish/tree/release/v1/?tab=readme-ov-file#trusted-publishing.
+      - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true


### PR DESCRIPTION
Replaces the release-on-published workflow with a workflow_dispatch workflow that:

- Calculates Calver version (YYYY.MM.DD)
- Updates CHANGELOG.rst (moves Next to dated section)
- Commits, tags, creates GitHub release
- Builds sdist and wheel, runs check-wheel-contents, publishes to PyPI

Based on requests-mock-flask. Requires `RELEASE_PAT` secret (PAT with repo scope) for pushing to protected branches.

Trigger with: `gh workflow run release.yml`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it replaces the release trigger/flow and introduces automated commits/tags/releases plus PyPI publishing; misconfiguration (permissions, PAT, tagging) could break releases or publish unintended versions.
> 
> **Overview**
> Replaces the `release` workflow trigger from `release: published` to manual `workflow_dispatch`, expanding it into an end-to-end release pipeline.
> 
> The workflow now **computes a CalVer tag (YYYY.MM.DD)**, updates `CHANGELOG.rst` by moving the `Next` header into a dated section, auto-commits that change, **creates/pushes a git tag and GitHub Release**, then builds sdist/wheel (with `check-wheel-contents`) and publishes to PyPI via **trusted publishing** (OIDC `id-token`).
> 
> Also updates action versions and adjusts checkout/permissions to use a `RELEASE_PAT` and `contents: write` for pushing commits/tags.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d74b884389bd66b89cf98c52eb8a6d869adb6d7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->