### PR TITLE
Document using responses in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ openapi-mock
 
 |Build Status| |PyPI|
 
-Serve an OpenAPI spec as a mock with `respx`_.
+Serve an OpenAPI spec as a mock with `respx`_ or `responses`_.
 
 .. |Build Status| image:: https://github.com/adamtheturtle/openapi-mock/actions/workflows/ci.yml/badge.svg?branch=main
    :target: https://github.com/adamtheturtle/openapi-mock/actions/workflows/ci.yml
@@ -26,6 +26,9 @@ Or with pip:
 Usage
 -----
 
+With respx (httpx)
+~~~~~~~~~~~~~~~~~~
+
 .. code-block:: python
 
    from http import HTTPStatus
@@ -44,4 +47,26 @@ Usage
        response = httpx.get(url="https://api.example.com/pets")
    assert response.status_code == HTTPStatus.OK
 
+With responses (requests)
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   from http import HTTPStatus
+
+   import requests
+   import responses
+
+   from openapi_mock import add_openapi_to_responses
+
+   spec = {
+       "openapi": "3.0.0",
+       "paths": {"/pets": {"get": {"responses": {"200": {"description": "OK"}}}}},
+   }
+   with responses.RequestsMock() as rsps:
+       add_openapi_to_responses(spec=spec, base_url="https://api.example.com", mock=rsps)
+       response = requests.get(url="https://api.example.com/pets", timeout=30)
+   assert response.status_code == HTTPStatus.OK
+
 .. _respx: https://lundberg.github.io/respx/
+.. _responses: https://github.com/getsentry/responses


### PR DESCRIPTION
## Summary

- Updates the tagline to mention both `respx` and `responses` backends
- Splits the Usage section into two subsections: "With respx (httpx)" and "With responses (requests)"
- Adds a `responses.RequestsMock` usage example with `add_openapi_to_responses`
- Adds a link to the `responses` library

Closes #142

## Test plan

- [ ] Review the rendered README to confirm both examples are clear and correct

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime behavior or APIs are modified.
> 
> **Overview**
> Updates `README.rst` to mention support for both `respx` and `responses`, and splits the Usage section into separate examples for each backend.
> 
> Adds a new `responses.RequestsMock` snippet demonstrating `add_openapi_to_responses`, and includes a reference link to the `responses` project.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 368f61df2dc36aac1697936dc1e677541253950c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->