### PR TITLE
Support Python 3.10 and 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: ['3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         platform: [ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.platform }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,12 @@ keywords = [ "httpx", "mock", "openapi", "respx" ]
 license = "MIT"
 license-files = [ "LICENSE" ]
 authors = [ { name = "Adam Dangoor", email = "adamdangoor@gmail.com" } ]
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
@@ -75,7 +77,7 @@ packages.find.where = [ "src" ]
 fallback_version = "0.0.0"
 
 [tool.ruff]
-target-version = "py312"
+target-version = "py310"
 line-length = 88
 lint.extend-select = [ "C901", "ERA001" ]
 lint.unfixable = [ "ERA001" ]


### PR DESCRIPTION
Lower the minimum Python version from 3.12 to 3.10. No source code changes needed — the codebase already uses only 3.10+ syntax. Updates `requires-python`, classifiers, ruff `target-version`, and the CI test matrix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes packaging metadata, lint target version, and CI test matrix, with no runtime/source-code changes.
> 
> **Overview**
> Lowers the supported minimum Python version from `>=3.12` to `>=3.10` and adds `3.10`/`3.11` trove classifiers.
> 
> Updates tooling/CI to match by setting Ruff’s `target-version` to `py310` and expanding the GitHub Actions test matrix to run on Python `3.10` and `3.11` (in addition to existing versions).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ba510d21f78ee1c610fd22232580bd2700ae053. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->