### PR TITLE
Run lint workflow on multiple Python versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        python-version: ['3.12', '3.13', '3.14']
         hook-stage: [pre-commit, pre-push, manual]
 
     runs-on: ubuntu-latest
@@ -37,6 +38,8 @@ jobs:
         shell: bash
         run: uv run --extra=dev prek run --all-files --hook-stage ${{ matrix.hook-stage }}
           --verbose
+        env:
+          UV_PYTHON: ${{ matrix.python-version }}
 
   pre-commit-ci-lite:
     needs: lint


### PR DESCRIPTION
Add a `python-version` matrix (`3.12`, `3.13`, `3.14`) to the lint GitHub Action, matching the CI workflow. The selected version is passed to the lint step via the `UV_PYTHON` environment variable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that expands the lint job matrix; the main impact is longer CI runtimes and potential new lint failures on newer Python versions.
> 
> **Overview**
> Updates the `Lint` GitHub Actions workflow to run the lint job across a `python-version` matrix (`3.12`, `3.13`, `3.14`) in addition to the existing `hook-stage` matrix.
> 
> Passes the selected Python version into the lint command via `UV_PYTHON`, ensuring `uv` runs pre-commit checks under each targeted interpreter.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9951907b272170f9edc3b05def3c99918b32cbae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->