### PR TITLE
Fix pre-commit.ci lite not reporting on PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,6 +42,8 @@ jobs:
           UV_PYTHON: ${{ matrix.python-version }}
 
   pre-commit-ci-lite:
+    permissions:
+      statuses: write
     needs: lint
     runs-on: ubuntu-latest
     if: always() && (needs.lint.result == 'success' || needs.lint.result == 'failure')


### PR DESCRIPTION
Grant `statuses: write` permission to the `pre-commit-ci-lite` job. The workflow-level `permissions: {}` was stripping all permissions from the GitHub token, preventing the lite action from posting check results to PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a minimal GitHub Actions permission tweak limited to the `pre-commit-ci-lite` job, affecting only CI status reporting.
> 
> **Overview**
> Fixes `pre-commit-ci-lite` not reporting results on PRs by adding job-level `permissions: { statuses: write }` to `.github/workflows/lint.yml`.
> 
> This overrides the workflow-wide `permissions: {}` restriction just for that job so the lite action can publish status checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5eba2371e4f954aaa689776c56f8aa298ffb8727. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->