### PR TITLE
chore: use deptry optional_dependencies_dev_groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,7 @@ ignore = [
 ]
 
 [tool.deptry]
-pep621_dev_dependency_groups = [ "dev", "release" ]
+optional_dependencies_dev_groups = [ "dev", "release" ]
 
 [tool.pyproject-fmt]
 indent = 4


### PR DESCRIPTION
Renames `pep621_dev_dependency_groups` to `optional_dependencies_dev_groups` for deptry 0.25+.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a config-only rename in `pyproject.toml` to match newer `deptry` versions, with no runtime code changes.
> 
> **Overview**
> Updates the `deptry` configuration in `pyproject.toml` by renaming `pep621_dev_dependency_groups` to `optional_dependencies_dev_groups`, keeping the same `dev`/`release` groups for dependency checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit add8688f63efce6b1961d728a205ca580a84d8ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->