### PR TITLE
Pin pytest-beartype-tests to 2026.4.20 on PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ optional-dependencies.dev = [
     "pyright==1.1.408",
     "pyroma==5.0.1",
     "pytest==9.0.3",
-    "pytest-beartype-tests",
+    "pytest-beartype-tests==2026.4.20",
     "pytest-cov==7.1.0",
     "ruff==0.15.11",
     "shellcheck-py==0.11.0.1",
@@ -79,7 +79,6 @@ packages.find.where = [ "src" ]
 fallback_version = "0.0.0"
 
 [tool.uv]
-sources.pytest-beartype-tests = { git = "https://github.com/adamtheturtle/pytest-beartype-tests.git", rev = "bc81d99" }
 
 [tool.ruff]
 target-version = "py312"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,8 +78,6 @@ packages.find.where = [ "src" ]
 [tool.setuptools_scm]
 fallback_version = "0.0.0"
 
-[tool.uv]
-
 [tool.ruff]
 target-version = "py312"
 line-length = 88

--- a/uv.lock
+++ b/uv.lock
@@ -988,7 +988,7 @@ requires-dist = [
     { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.408" },
     { name = "pyroma", marker = "extra == 'dev'", specifier = "==5.0.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.0.3" },
-    { name = "pytest-beartype-tests", marker = "extra == 'dev'", git = "https://github.com/adamtheturtle/pytest-beartype-tests.git?rev=bc81d99" },
+    { name = "pytest-beartype-tests", marker = "extra == 'dev'", specifier = "==2026.4.20" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==7.1.0" },
     { name = "responses", specifier = ">=0.25.3" },
     { name = "respx", specifier = ">=0.22.0" },
@@ -1399,11 +1399,15 @@ wheels = [
 
 [[package]]
 name = "pytest-beartype-tests"
-version = "2026.4.19.1.post5+gbc81d99a1"
-source = { git = "https://github.com/adamtheturtle/pytest-beartype-tests.git?rev=bc81d99#bc81d99a1041e4d24bd67a2eec077b6d6616e712" }
+version = "2026.4.20"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
     { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/0e/f3b3980efe46c7655ce2820fe56189490f9c1e6ed5cb42b35999b4ba8238/pytest_beartype_tests-2026.4.20.tar.gz", hash = "sha256:73b10d64c5605809444469250c3ccc8b4ddbf788772be84f0ee0ac3f58460ccf", size = 85989, upload-time = "2026-04-20T06:28:22.773Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/42/ee5023bf416be8ffc276a08e42eac10aee1903142a1e25ceea24cc766b73/pytest_beartype_tests-2026.4.20-py3-none-any.whl", hash = "sha256:e61e7bd87443f92c89f125cc8a7284665c5137e953ecd91031be1620ba07c1d8", size = 5215, upload-time = "2026-04-20T06:28:21.166Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Replace the temporary `[tool.uv.sources]` git pin to bc81d99 with the published PyPI release `pytest-beartype-tests==2026.4.20` (same Sybil-safe plugin behavior).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency source/pinning change only (git -> PyPI) with no production code modifications; main risk is CI/test behavior drift if the PyPI build differs from the previously pinned commit.
> 
> **Overview**
> Updates dev dependencies to use the published PyPI release `pytest-beartype-tests==2026.4.20` instead of the temporary git-based `uv` source override.
> 
> Regenerates `uv.lock` to reflect the new registry source (removing the git revision metadata and adding the PyPI sdist/wheel entries).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f314c9cdfceeb055d83596e34ca809295dd6892. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->