### PR TITLE
chore: bump uv to 0.11.7 for pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 fail_fast: true
 
-.uv_version: &uv_version uv==0.9.5
+.uv_version: &uv_version uv==0.11.7
 
 ci:
   skip:


### PR DESCRIPTION
Bumps the uv pin in `.pre-commit-config.yaml` (`.uv_version` YAML anchor) to **uv 0.11.7**, matching the current [astral-sh/uv](https://github.com/astral-sh/uv) release used for pre-commit local hooks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-version bump for dev tooling; no runtime, security, or data-handling logic is affected.
> 
> **Overview**
> Updates the pinned `uv` version used by local `pre-commit` hooks by changing the `.uv_version` YAML anchor in `.pre-commit-config.yaml` from `uv==0.9.5` to `uv==0.11.7`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e76ff2b7d39ec5e887161db855295b1da1fd0f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->