### PR TITLE
Bump mypy to 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ optional-dependencies.dev = [
     "doccmd==2026.3.26.2",
     "furo==2025.12.19",
     "interrogate==1.7.0",
-    "mypy[faster-cache]==1.20.2",
+    "mypy[faster-cache]==2.0.0",
     "mypy-strict-kwargs==2026.1.12",
     "prek==0.3.13",
     "pydocstringformatter==0.7.5",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this only changes a pinned dev dependency version and does not affect runtime code paths. Potential impact is limited to stricter/different type-checking results in CI/local dev.
> 
> **Overview**
> Bumps the pinned dev dependency `mypy[faster-cache]` from `1.20.2` to `2.0.0` in `pyproject.toml` to use the new major release of mypy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9afd427119f766d4f2f0c545c609f1600142a412. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->