### PR TITLE
Enable mypy parallel workers in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -153,7 +153,8 @@ repos:
       - id: mypy-docs
         name: mypy-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy --num-workers=4"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy
+          --num-workers=4"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [*uv_version]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -144,6 +144,7 @@ repos:
         name: mypy
         stages: [pre-push]
         entry: uv run --extra=dev -m mypy
+        args: [--num-workers=4]
         language: python
         types_or: [python, toml]
         pass_filenames: false
@@ -154,6 +155,7 @@ repos:
         name: mypy-docs
         stages: [pre-push]
         entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy"
+        args: [--num-workers=4]
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [*uv_version]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -154,8 +154,7 @@ repos:
       - id: mypy-docs
         name: mypy-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy"
-        args: [--num-workers=4]
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy --num-workers=4"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [*uv_version]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -143,8 +143,7 @@ repos:
       - id: mypy
         name: mypy
         stages: [pre-push]
-        entry: uv run --extra=dev -m mypy
-        args: [--num-workers=4]
+        entry: uv run --extra=dev -m mypy --num-workers=4
         language: python
         types_or: [python, toml]
         pass_filenames: false


### PR DESCRIPTION
## Summary
- add `--num-workers=4` to `mypy` pre-commit hook args
- add `--num-workers=4` to `mypy-docs` pre-commit hook args

## Test plan
- not run (config-only change)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that only affects local `pre-push` type-check execution performance/behavior; potential risk is different mypy scheduling exposing timing-related plugin issues.
> 
> **Overview**
> Speeds up `pre-push` type checking by running `mypy` with `--num-workers=4`.
> 
> Applies the same parallelism flag to the `mypy-docs` `doccmd` invocation so doc snippets are type-checked with the same worker configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dad8ef8cc98635220bf06d6e1bd5155d9850d3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->