### PR TITLE
[codex] Make useless Pylint suppressions fail lint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,10 @@ MASTER.load-plugins = [
     "pylint.extensions.bad_builtin",
 ]
 MASTER.jobs = 0
+# Return non-zero exit code if useless-suppression is emitted.
+MAIN.fail-on = [
+    "useless-suppression",
+]
 DEPRECATED_BUILTINS.bad-functions = [
     # Use Pylint until Ruff can ban bare builtin calls, or until custom rules
     # make this removable:


### PR DESCRIPTION
## Summary

- Configure Pylint to fail when `useless-suppression` is emitted.
- Keep existing project-specific Pylint settings intact.

## Validation

- Parsed `pyproject.toml` with `tomllib`.
- Ran `pylint --rcfile pyproject.toml --list-msgs-enabled`.
- Ran repository commit hooks for the changed file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only tightens lint configuration, but it may cause CI to fail if the repo currently contains `# pylint: disable` directives that no longer suppress any warnings.
> 
> **Overview**
> Pylint is now configured to **fail the lint run** when it emits `useless-suppression` by adding `MAIN.fail-on = ["useless-suppression"]` in `pyproject.toml`, preventing stale/ineffective suppression comments from silently accumulating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d40603528a52a94068435dcb579119f96f85ccf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->