### PR TITLE
Bump beartype to 0.23.0rc0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 dynamic = [ "version" ]
 dependencies = [
-    "beartype>=0.18",
+    "beartype==0.23.0rc0",
     "httpx>=0.27.0",
     "openapi-pydantic>=0.5.0",
     "pydantic>=2.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -134,11 +134,11 @@ wheels = [
 
 [[package]]
 name = "beartype"
-version = "0.22.9"
+version = "0.23.0rc0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload-time = "2025-12-13T06:50:30.72Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/6d/158a00013b4b7726d69aa273eab7a5f329ea973edc0c626c4394c50231e5/beartype-0.23.0rc0.tar.gz", hash = "sha256:3cc8fd69a9a1f4a9ee5bdc20cd9c26962e2db3ef4c388e3181dd7f226c5c5d6f", size = 1928474, upload-time = "2026-08-08T07:26:47.964Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload-time = "2025-12-13T06:50:28.266Z" },
+    { url = "https://files.pythonhosted.org/packages/25/a3/ba8699a1361099ff9162c9b5de6e024f75c2dff1f753c2b58beb719d9519/beartype-0.23.0rc0-py3-none-any.whl", hash = "sha256:5a6647bc6a777ead26fb1a781831aea95e29975cae8db26d5882f6147a45fae3", size = 1530796, upload-time = "2026-08-08T07:26:45.829Z" },
 ]
 
 [[package]]
@@ -1031,7 +1031,7 @@ release = [
 [package.metadata]
 requires-dist = [
     { name = "actionlint-py", marker = "extra == 'dev'", specifier = "==1.7.12.24" },
-    { name = "beartype", specifier = ">=0.18" },
+    { name = "beartype", specifier = "==0.23.0rc0" },
     { name = "check-manifest", marker = "extra == 'dev'", specifier = "==0.51" },
     { name = "check-wheel-contents", marker = "extra == 'release'", specifier = "==0.6.3" },
     { name = "deptry", marker = "extra == 'dev'", specifier = "==0.25.1" },


### PR DESCRIPTION
Tests the [beartype 0.23.0rc0](https://pypi.org/project/beartype/0.23.0rc0/) release candidate against this repository's test suite.

Pins `beartype` to the release candidate in `pyproject.toml` and updates `uv.lock` to match.

Not intended to merge as-is — the pin should be relaxed once the release candidate has been evaluated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump with no application code changes; risk is limited to possible beartype runtime/type-check behavior differences during RC testing.
> 
> **Overview**
> **Pins the runtime `beartype` dependency** from a flexible `>=0.18` constraint to an exact **`beartype==0.23.0rc0`** so CI and local installs exercise the 0.23 release candidate against this repo’s tests (including `pytest-beartype-tests`).
> 
> **`uv.lock` is refreshed** so the resolved package moves from **0.22.9** to **0.23.0rc0** with updated wheel/sdist hashes. No library source changes—only dependency metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47fe09ddda3f5c12e555cae14cff8f5847092a33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->